### PR TITLE
Feature: Load to XML for Descriptions

### DIFF
--- a/doc/changelog.html
+++ b/doc/changelog.html
@@ -17,6 +17,7 @@
                         <ul>
                             <li>Authors can be sorted by drag & drop</li>
                             <li>Link to imprint of GFZ Data Services</li>
+                            <li>Loading from XML file extended by Descriptions</li>
                         </ul>
                     </li>
                     <li><strong>Fixed Bugs:</strong>

--- a/js/mappingXmlToInputFields.js
+++ b/js/mappingXmlToInputFields.js
@@ -713,6 +713,59 @@ function populateFormWithContributors(personMap, orgMap) {
 }
 
 /**
+ * Process descriptions from XML and populate the form
+ * @param {Document} xmlDoc - The parsed XML document
+ * @param {Function} resolver - The namespace resolver function
+ */
+function processDescriptions(xmlDoc, resolver) {
+  // Get all description elements
+  const descriptionNodes = xmlDoc.evaluate(
+    './/ns:descriptions/ns:description',
+    xmlDoc,
+    resolver,
+    XPathResult.ORDERED_NODE_SNAPSHOT_TYPE,
+    null
+  );
+
+  // Create a mapping of description types to form input IDs
+  const descriptionMapping = {
+    'Abstract': 'input-abstract',
+    'Methods': 'input-methods',
+    'TechnicalInformation': 'input-technicalinfo',
+    'Other': 'input-other'
+  };
+
+  // Reset all description fields first
+  Object.values(descriptionMapping).forEach(inputId => {
+    $(`#${inputId}`).val('');
+  });
+
+  // Process each description node
+  for (let i = 0; i < descriptionNodes.snapshotLength; i++) {
+    const descriptionNode = descriptionNodes.snapshotItem(i);
+    const descriptionType = descriptionNode.getAttribute('descriptionType');
+    const language = descriptionNode.getAttribute('xml:lang') || 'en';
+    const content = descriptionNode.textContent.trim();
+
+    // Find the corresponding input field
+    const inputId = descriptionMapping[descriptionType];
+    if (inputId) {
+      // Set the content in the appropriate textarea
+      $(`#${inputId}`).val(content);
+
+      // If this is not the Abstract, expand the corresponding accordion section
+      if (descriptionType !== 'Abstract') {
+        const collapseId = `collapse-${descriptionType.toLowerCase().replace('information', 'info')}`;
+        $(`#${collapseId}`).addClass('show');
+      }
+    }
+  }
+
+  // Ensure Abstract accordion is always expanded
+  $('#collapse-abstract').addClass('show');
+}
+
+/**
  * Loads XML data into form fields according to mapping configuration
  * @param {Document} xmlDoc - The parsed XML document
  */
@@ -871,4 +924,6 @@ async function loadXmlToForm(xmlDoc) {
   processOriginatingLaboratories(xmlDoc, resolver);
   // Process contributors
   processContributors(xmlDoc, resolver);
+  // Process descriptions
+  processDescriptions(xmlDoc, resolver);
 }


### PR DESCRIPTION
Dieser Pull Request ergänzt das **Laden der Descriptions aus der hochgeladenen XML-Datei**.

## Changes
### Enhancements to XML processing
* [`js/mappingXmlToInputFields.js`](diffhunk://#diff-67c1fa1d0f6d5ed82d952e3b2cdacac9fa7f7565e11567a1224cae30c3ad4b85R715-R767): Added a new function `processDescriptions` to process description elements from an XML document and populate the form fields accordingly. This includes mapping description types to form input IDs, resetting all description fields, and setting the content in the appropriate text areas.
* [`js/mappingXmlToInputFields.js`](diffhunk://#diff-67c1fa1d0f6d5ed82d952e3b2cdacac9fa7f7565e11567a1224cae30c3ad4b85R927-R928): Updated the `loadXmlToForm` function to call the new `processDescriptions` function, ensuring that descriptions are processed when loading XML data into form fields.

### Documentation updates
* [`doc/changelog.html`](diffhunk://#diff-7f42e3dbab923ae06d6408cdca2b7166f6e9225a228fcbd07b2d8a18074464cbR20): Added an entry to the changelog to indicate that loading from XML files has been extended to include descriptions.

## Notes for Reviewer
Dass das Accordion (entgegen der eigentlich angedachten Funktion eines Accordion) vollständig aufgeklappt dargestellt wird, nach dem Upload einer Datei ist Absicht. Die Funktion des Accordion wird dadurch nicht beeinträchtigt und beim Zuklappen der einzelnen "Falten" widerhergestellt.

## Checklist
- [x] Mein Code folgt dem Style Guide.
- [x] Ich habe selbst eine Code Review durchgeführt.
- [x] Ich habe Kommentare zu schwer verständlichem Code hinzugefügt.
- [x] Ich habe PHP-Code nach PHPDoc-Standard dokumentiert bzw. die Code-Dokumentation angepasst.
- [x] Ich habe JavaScript-Code nach JSDoc-Standard dokumentiert bzw. die Code-Dokumentation angepasst.
- [x] Ich habe, wenn nötig, entsprechende Änderungen im ELMO Guide vorgenommen.
- [x] Ich habe, wenn nötig, entsprechende Änderungen in der ReadMe vorgenommen.
- [x] Ich habe, wenn nötig, entsprechende Änderungen in der API-Dokumentation vorgenommen.
- [x] Falls ich ein neues Feature implementiert oder einen Bug gefixt habe, wurde der Changelog erweitert
- [x] Meine Änderungen erzeugen keine neuen Warnungen in der Konsole des Testbrowsers
- [x] Ich habe Unit-Tests hinzugefügt, die meinen Code abdecken
- [x] Neue und bereits vorhandene Unit-Tests werden lokal bestanden
- [x] Neue und bereits vorhandende automatische Unit-Tests werden im Pull Request bestanden
- [x] Ich habe, wenn nötig die Selenium-Tests aktualisiert und ggf. neue hinzugefügt
- [x] Neue und bereits vorhandene automatisierte Selenium-Tests werden im Pull Request bestanden
- [x] Ich habe sicher gestellt, dass die Änderungen den Barrierefreiheitsrichtlinien entsprechen.


## Known Issues
_Keine._
