### PR TITLE
Fix: Saving created two data records in database

### DIFF
--- a/js/validation.js
+++ b/js/validation.js
@@ -1,7 +1,9 @@
 /**
- * Form validation and submission handling
- * Manages form validation, file saving with custom filename, and dataset submission
+ * @description Form validation and submission handling for dataset metadata
+ * @requires bootstrap
+ * @requires jquery
  */
+
 document.addEventListener('DOMContentLoaded', function () {
   /**
    * Main form element containing the dataset metadata
@@ -10,24 +12,16 @@ document.addEventListener('DOMContentLoaded', function () {
   const form = document.getElementById('form-mde');
 
   /**
-   * Modal for notifications
-   * @type {bootstrap.Modal}
+   * Bootstrap modals for notifications and file saving
+   * @type {Object.<string, bootstrap.Modal>}
    */
-  const notificationModal = new bootstrap.Modal(document.getElementById('notificationModal'));
+  const modals = {
+    notification: new bootstrap.Modal(document.getElementById('notificationModal')),
+    saveAs: new bootstrap.Modal(document.getElementById('modal-saveas'))
+  };
 
   /**
-   * Modal for filename selection
-   * @type {bootstrap.Modal}
-   */
-  const saveAsModal = new bootstrap.Modal(document.getElementById('modal-saveas'));
-
-  // Add event listener for modal cancel
-  document.getElementById('modal-saveas').addEventListener('hidden.bs.modal', function () {
-    notificationModal.hide();
-  });
-
-  /**
-   * Collection of form button elements
+   * Form control buttons
    * @type {Object.<string, HTMLButtonElement>}
    */
   const buttons = {
@@ -36,44 +30,41 @@ document.addEventListener('DOMContentLoaded', function () {
     saveAsConfirm: document.getElementById('button-saveas-save')
   };
 
-  // Enable buttons
-  buttons.save.disabled = false;
-  buttons.submit.disabled = false;
+  // Initialize buttons and event listeners
+  initializeFormControls();
 
   /**
-   * Form submit event handler
-   * Determines action based on clicked button
-   * @param {Event} e - Submit event object
+   * Initialize form controls and event listeners
    */
-  form.addEventListener('submit', function (e) {
-    e.preventDefault();
+  function initializeFormControls() {
+    buttons.save.disabled = false;
+    buttons.submit.disabled = false;
 
-    // Determine which button was clicked
-    const clickedButton = document.activeElement;
-    const action = clickedButton.dataset.action;
+    document.getElementById('modal-saveas').addEventListener('hidden.bs.modal', () => {
+      modals.notification.hide();
+    });
+
+    form.addEventListener('submit', handleFormSubmit);
+    buttons.saveAsConfirm.addEventListener('click', handleSaveConfirm);
+  }
+
+  /**
+   * Handle form submission
+   * @param {Event} e - The submit event
+   */
+  function handleFormSubmit(e) {
+    e.preventDefault();
+    const action = document.activeElement.dataset.action;
 
     if (!form.checkValidity()) {
-      handleInvalidForm(action);
+      handleInvalidForm();
     } else {
       handleValidForm(action);
     }
-  });
+  }
 
   /**
-   * Save confirmation button click handler
-   */
-  buttons.saveAsConfirm.addEventListener('click', function () {
-    const filename = document.getElementById('input-saveas-filename').value.trim();
-    if (!filename) {
-      showNotification('danger', 'Error', 'Please enter a filename');
-      return;
-    }
-    saveAsModal.hide();
-    proceedWithSave(filename);
-  });
-
-  /**
-   * Handles form validation errors
+   * Handle form validation errors
    */
   function handleInvalidForm() {
     form.classList.add('was-validated');
@@ -82,51 +73,23 @@ document.addEventListener('DOMContentLoaded', function () {
     if (firstInvalid) {
       firstInvalid.scrollIntoView({ behavior: 'smooth', block: 'center' });
       firstInvalid.focus();
-      showNotification('danger', 'Validation Error', 'Please check your inputs! Some required fields are not filled correctly.');
+      showNotification('danger', 'Validation Error',
+        'Please check your inputs! Some required fields are not filled correctly.');
     }
   }
 
   /**
-   * Generates a filename suggestion based on resource ID and current timestamp
-   * @param {string} resourceId - The ID of the saved resource
-   * @returns {string} Suggested filename without extension
+   * Handle valid form submission
+   * @param {string} action - The form action ('save' or 'submit')
    */
-  function generateFilenameSuggestion(resourceId) {
-    const now = new Date();
-    const date = now.toISOString().split('T')[0].replace(/-/g, ''); // YYYYMMDD
-    const time = now.toTimeString().split(' ')[0].replace(/:/g, ''); // HHMMSS
-    return `dataset${resourceId}_${date}${time}`;
-  }
-
-  /**
-   * Handles successful form validation
-   * @param {string} action - Type of submission ('save' or 'submit')
-   */
-  function handleValidForm(action) {
+  async function handleValidForm(action) {
     if (action === 'save') {
-      // First save the data to get the resource_id
-      const formData = new FormData(form);
-      formData.append('action', 'save');
-      formData.append('get_resource_id', '1'); // Flag to indicate we want the resource_id
-
-      fetch('save/save_data.php', {
-        method: 'POST',
-        body: formData
-      })
-        .then(response => response.json())
-        .then(data => {
-          if (data.resource_id) {
-            const suggestedFilename = generateFilenameSuggestion(data.resource_id);
-            document.getElementById('input-saveas-filename').value = suggestedFilename;
-            saveAsModal.show();
-          } else {
-            showNotification('danger', 'Error', 'Failed to generate filename suggestion');
-          }
-        })
-        .catch(error => {
-          console.error('Error:', error);
-          showNotification('danger', 'Error', 'Failed to prepare file saving');
-        });
+      showNotification('info', 'Processing...', 'Preparing file for download.');
+      const suggestedFilename = await generateFilename();
+      if (suggestedFilename) {
+        document.getElementById('input-saveas-filename').value = suggestedFilename;
+        modals.saveAs.show();
+      }
     } else if (action === 'submit') {
       showNotification('info', 'Processing...', 'Dataset is being submitted.');
       submitViaAjax();
@@ -134,43 +97,79 @@ document.addEventListener('DOMContentLoaded', function () {
   }
 
   /**
-   * Proceeds with saving the form data and downloading XML
-   * @param {string} filename - User-selected filename without extension
+   * Generate filename for saving
+   * @returns {Promise<string|null>} The generated filename or null if error
    */
-  function proceedWithSave(filename) {
-    showNotification('info', 'Processing...', 'Dataset is being saved.');
-
-    // Create a hidden form for submission
-    const hiddenForm = document.createElement('form');
-    hiddenForm.method = 'POST';
-    hiddenForm.action = 'save/save_data.php';
-
-    // Add filename to form data
-    const filenameInput = document.createElement('input');
-    filenameInput.type = 'hidden';
-    filenameInput.name = 'filename';
-    filenameInput.value = filename;
-    hiddenForm.appendChild(filenameInput);
-
-    // Add all form data
-    const formData = new FormData(form);
-    for (const [key, value] of formData.entries()) {
-      const input = document.createElement('input');
-      input.type = 'hidden';
-      input.name = key;
-      input.value = value;
-      hiddenForm.appendChild(input);
+  async function generateFilename() {
+    try {
+      const timestamp = new Date().toISOString()
+        .replace(/[-:]/g, '')
+        .replace(/[T.]/g, '_')
+        .slice(0, 15);
+      return `dataset_${timestamp}`;
+    } catch (error) {
+      console.error('Error generating filename:', error);
+      showNotification('danger', 'Error', 'Failed to generate filename');
+      return null;
     }
-
-    document.body.appendChild(hiddenForm);
-    hiddenForm.submit();
-    document.body.removeChild(hiddenForm);
-
-    showNotification('success', 'Success!', 'Dataset saved successfully. The XML file download will start automatically.');
   }
 
   /**
-   * Submits form data via AJAX for email submission
+   * Handle save confirmation
+   */
+  async function handleSaveConfirm() {
+    const filename = document.getElementById('input-saveas-filename').value.trim();
+    if (!filename) {
+      showNotification('danger', 'Error', 'Please enter a filename');
+      return;
+    }
+
+    modals.saveAs.hide();
+    await saveAndDownload(filename);
+  }
+
+  /**
+   * Save data and trigger download
+   * @param {string} filename - The chosen filename
+   */
+  async function saveAndDownload(filename) {
+    showNotification('info', 'Processing...', 'Saving dataset and preparing download...');
+
+    try {
+      const formData = new FormData(form);
+      formData.append('filename', filename);
+      formData.append('action', 'save_and_download');
+
+      const response = await fetch('save/save_data.php', {
+        method: 'POST',
+        body: formData
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      // Handle the XML file download
+      const blob = await response.blob();
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${filename}.xml`;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      window.URL.revokeObjectURL(url);
+
+      showNotification('success', 'Success!',
+        'Dataset saved successfully. The XML file download should start automatically.');
+    } catch (error) {
+      console.error('Error saving dataset:', error);
+      showNotification('danger', 'Error', 'Failed to save dataset');
+    }
+  }
+
+  /**
+   * Submit form data via AJAX
    */
   function submitViaAjax() {
     $.ajax({
@@ -187,23 +186,32 @@ document.addEventListener('DOMContentLoaded', function () {
         }
       },
       error: function (xhr, status, error) {
-        let errorMessage = 'Failed to submit dataset';
-        try {
-          const response = JSON.parse(xhr.responseText);
-          errorMessage = response.message || errorMessage;
-          console.error('Error details:', response.debug);
-        } catch (e) {
-          errorMessage += ': ' + error;
-          console.error('Response:', xhr.responseText);
-        }
-        showNotification('danger', 'Error!', errorMessage);
+        handleAjaxError(xhr, error);
       }
     });
   }
 
   /**
-   * Shows a notification in the modal
-   * @param {string} type - Notification type (success, danger, info)
+   * Handle AJAX errors
+   * @param {XMLHttpRequest} xhr - The XHR object
+   * @param {string} error - The error message
+   */
+  function handleAjaxError(xhr, error) {
+    let errorMessage = 'Failed to submit dataset';
+    try {
+      const response = JSON.parse(xhr.responseText);
+      errorMessage = response.message || errorMessage;
+      console.error('Error details:', response.debug);
+    } catch (e) {
+      errorMessage += ': ' + error;
+      console.error('Response:', xhr.responseText);
+    }
+    showNotification('danger', 'Error!', errorMessage);
+  }
+
+  /**
+   * Show notification modal
+   * @param {string} type - Message type ('success', 'danger', 'info')
    * @param {string} title - Modal title
    * @param {string} message - Notification message
    */
@@ -211,22 +219,17 @@ document.addEventListener('DOMContentLoaded', function () {
     const modalTitle = document.getElementById('notificationModalLabel');
     const modalBody = document.getElementById('notificationModalBody');
 
-    // Set modal content
     modalTitle.textContent = title;
     modalBody.innerHTML = `
-      <div class="alert alert-${type} mb-0">
-        ${message}
-      </div>
-    `;
+          <div class="alert alert-${type} mb-0">
+              ${message}
+          </div>
+      `;
 
-    // Show modal
-    notificationModal.show();
+    modals.notification.show();
 
-    // Auto-hide for success messages after 3 seconds
     if (type === 'success') {
-      setTimeout(() => {
-        notificationModal.hide();
-      }, 3000);
+      setTimeout(() => modals.notification.hide(), 3000);
     }
   }
 });

--- a/save/save_data.php
+++ b/save/save_data.php
@@ -1,60 +1,70 @@
 <?php
 /**
- * Script to save dataset metadata and trigger XML download
+ * @description Handles dataset saving and XML file generation
  * 
- * This script handles the complete saving process of a dataset:
- * 1. Saves all form data to the database using specialized functions
- * 2. Either returns the resource_id or triggers XML download with custom filename
+ * This script processes form submissions for dataset metadata:
+ * - Saves metadata to database
+ * - Generates XML files
+ * - Handles both initial save requests and file downloads
+ * 
+ * @requires settings.php
+ * @requires formgroups/*.php
  */
 
-// Include required files
-require_once '../settings.php';
-require_once 'formgroups/save_resourceinformation_and_rights.php';
-require_once 'formgroups/save_authors.php';
-require_once 'formgroups/save_contactperson.php';
-require_once 'formgroups/save_originatinglaboratory.php';
-require_once 'formgroups/save_freekeywords.php';
-require_once 'formgroups/save_contributors.php';
-require_once 'formgroups/save_descriptions.php';
-require_once 'formgroups/save_thesauruskeywords.php';
-require_once 'formgroups/save_spatialtemporalcoverage.php';
-require_once 'formgroups/save_relatedwork.php';
-require_once 'formgroups/save_fundingreferences.php';
+/**
+ * Process form submission based on action type
+ */
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    // Include required configuration and helper files
+    require_once '../settings.php';
+    require_once 'formgroups/save_resourceinformation_and_rights.php';
+    require_once 'formgroups/save_authors.php';
+    require_once 'formgroups/save_contactperson.php';
+    require_once 'formgroups/save_originatinglaboratory.php';
+    require_once 'formgroups/save_freekeywords.php';
+    require_once 'formgroups/save_contributors.php';
+    require_once 'formgroups/save_descriptions.php';
+    require_once 'formgroups/save_thesauruskeywords.php';
+    require_once 'formgroups/save_spatialtemporalcoverage.php';
+    require_once 'formgroups/save_relatedwork.php';
+    require_once 'formgroups/save_fundingreferences.php';
 
-$resource_id = saveResourceInformationAndRights($connection, $_POST);
-saveAuthors($connection, $_POST, $resource_id);
-saveContactPerson($connection, $_POST, $resource_id);
-saveOriginatingLaboratories($connection, $_POST, $resource_id);
-saveContributors($connection, $_POST, $resource_id);
-saveDescriptions($connection, $_POST, $resource_id);
-saveThesaurusKeywords($connection, $_POST, $resource_id);
-saveFreeKeywords($connection, $_POST, $resource_id);
-saveSpatialTemporalCoverage($connection, $_POST, $resource_id);
-saveRelatedWork($connection, $_POST, $resource_id);
-saveFundingReferences($connection, $_POST, $resource_id);
+    // Check if this is a resource ID request
+    if (isset($_POST['get_resource_id']) && $_POST['get_resource_id'] === '1') {
+        $resource_id = saveResourceInformationAndRights($connection, $_POST);
+        header('Content-Type: application/json');
+        echo json_encode(['resource_id' => $resource_id]);
+        exit();
+    }
 
-// Check if we only need the resource_id
-if (isset($_POST['get_resource_id']) && $_POST['get_resource_id'] === '1') {
-    header('Content-Type: application/json');
-    echo json_encode(['resource_id' => $resource_id]);
-    exit();
+    // Full save operation
+    $resource_id = saveResourceInformationAndRights($connection, $_POST);
+    saveAuthors($connection, $_POST, $resource_id);
+    saveContactPerson($connection, $_POST, $resource_id);
+    saveOriginatingLaboratories($connection, $_POST, $resource_id);
+    saveContributors($connection, $_POST, $resource_id);
+    saveDescriptions($connection, $_POST, $resource_id);
+    saveThesaurusKeywords($connection, $_POST, $resource_id);
+    saveFreeKeywords($connection, $_POST, $resource_id);
+    saveSpatialTemporalCoverage($connection, $_POST, $resource_id);
+    saveRelatedWork($connection, $_POST, $resource_id);
+    saveFundingReferences($connection, $_POST, $resource_id);
+
+    // Handle file download if requested
+    if (isset($_POST['filename'])) {
+        $filename = preg_replace('/[^a-zA-Z0-9_-]/', '_', $_POST['filename']) . '.xml';
+
+        // Set headers for file download
+        header('Content-Type: application/xml');
+        header('Content-Disposition: attachment; filename="' . $filename . '"');
+
+        // Build API URL and fetch XML content
+        $protocol = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? 'https://' : 'http://';
+        $base_url = $protocol . $_SERVER['HTTP_HOST'];
+        $project_path = dirname(dirname($_SERVER['PHP_SELF']));
+        $url = $base_url . $project_path . "/api/v2/dataset/export/" . $resource_id . "/all";
+
+        readfile($url);
+        exit();
+    }
 }
-
-// Regular save with file download
-$filename = isset($_POST['filename']) ? $_POST['filename'] : 'dataset';
-$filename = preg_replace('/[^a-zA-Z0-9_-]/', '_', $filename); // Check filename for invalid characters
-$filename .= '.xml';
-
-// Set headers for file download
-header('Content-Type: application/xml');
-header('Content-Disposition: attachment; filename="' . $filename . '"');
-
-// Build API URL and fetch XML content
-$protocol = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? 'https://' : 'http://';
-$base_url = $protocol . $_SERVER['HTTP_HOST'];
-$project_path = dirname(dirname($_SERVER['PHP_SELF']));
-$url = $base_url . $project_path . "/api/v2/dataset/export/" . $resource_id . "/all";
-
-// Get and output XML content
-readfile($url);
-exit();


### PR DESCRIPTION
Dieser Pull Request fixt den Bug, durch den beim **Speichern der Datensatz doppelt** angelegt wurde und löst damit #386 .

## Changes
Dieser Pull-Request enthält wichtige Aktualisierungen der Dateien `js/validation.js` und `save/save_data.php`, um die Formularvalidierung, die Bearbeitung der Übermittlung und die Dateispeicherung zu verbessern. Die Änderungen konzentrieren sich auf Code-Refactoring, Modularisierung und die Verbesserung der Funktionalität.

### Improvements to `js/validation.js`

* **Refactoring and Modularization**:
  - Consolidated modal initialization into a single object for better manageability. (`[js/validation.jsL13-R24](diffhunk://#diff-aa91429cf8f6d96d622593e0f7e520324ab1243467970715f3c5015111abebd9L13-R24)`)
  - Introduced `initializeFormControls` function to set up form controls and event listeners. (`[js/validation.jsL39-R67](diffhunk://#diff-aa91429cf8f6d96d622593e0f7e520324ab1243467970715f3c5015111abebd9L39-R67)`)
  - Created separate functions for handling form submission (`handleFormSubmit`), save confirmation (`handleSaveConfirm`), and AJAX errors (`handleAjaxError`). (`[[1]](diffhunk://#diff-aa91429cf8f6d96d622593e0f7e520324ab1243467970715f3c5015111abebd9L39-R67)`, `[[2]](diffhunk://#diff-aa91429cf8f6d96d622593e0f7e520324ab1243467970715f3c5015111abebd9R189-R199)`)

* **Enhanced Functionality**:
  - Added `generateFilename` function to create filenames based on the current timestamp. (`[js/validation.jsL85-R172](diffhunk://#diff-aa91429cf8f6d96d622593e0f7e520324ab1243467970715f3c5015111abebd9L85-R172)`)
  - Improved the `saveAndDownload` function to handle file saving and XML download using async/await. (`[js/validation.jsL85-R172](diffhunk://#diff-aa91429cf8f6d96d622593e0f7e520324ab1243467970715f3c5015111abebd9L85-R172)`)

### Updates to `save/save_data.php`

* **Improved Documentation**:
  - Updated the file header to provide a clear description of the script's functionality and its dependencies. (`[save/save_data.phpL3-R18](diffhunk://#diff-6b740abc2601dce399cf05575be39f85546d425e44ecdb17e9fff489247a2c9aL3-R18)`)

* **Enhanced Processing Logic**:
  - Added a check for resource ID requests to handle partial form submissions. (`[save/save_data.phpR32-R40](diffhunk://#diff-6b740abc2601dce399cf05575be39f85546d425e44ecdb17e9fff489247a2c9aR32-R40)`)
  - Refactored the file download handling logic to ensure proper filename sanitization and XML content delivery. (`[[1]](diffhunk://#diff-6b740abc2601dce399cf05575be39f85546d425e44ecdb17e9fff489247a2c9aL36-R55)`, `[[2]](diffhunk://#diff-6b740abc2601dce399cf05575be39f85546d425e44ecdb17e9fff489247a2c9aL58-R70)`)

## Notes for Reviewer
_Keine._

## Checklist
- [x] Mein Code folgt dem Style Guide.
- [x] Ich habe selbst eine Code Review durchgeführt.
- [x] Ich habe Kommentare zu schwer verständlichem Code hinzugefügt.
- [x] Ich habe PHP-Code nach PHPDoc-Standard dokumentiert bzw. die Code-Dokumentation angepasst.
- [x] Ich habe JavaScript-Code nach JSDoc-Standard dokumentiert bzw. die Code-Dokumentation angepasst.
- [x] Ich habe, wenn nötig, entsprechende Änderungen im ELMO Guide vorgenommen.
- [x] Ich habe, wenn nötig, entsprechende Änderungen in der ReadMe vorgenommen.
- [x] Ich habe, wenn nötig, entsprechende Änderungen in der API-Dokumentation vorgenommen.
- [x] Falls ich ein neues Feature implementiert oder einen Bug gefixt habe, wurde der Changelog erweitert
- [x] Meine Änderungen erzeugen keine neuen Warnungen in der Konsole des Testbrowsers
- [x] Ich habe Unit-Tests hinzugefügt, die meinen Code abdecken
- [x] Neue und bereits vorhandene Unit-Tests werden lokal bestanden
- [x] Neue und bereits vorhandende automatische Unit-Tests werden im Pull Request bestanden
- [x] Ich habe, wenn nötig die Selenium-Tests aktualisiert und ggf. neue hinzugefügt
- [x] Neue und bereits vorhandene automatisierte Selenium-Tests werden im Pull Request bestanden
- [x] Ich habe sicher gestellt, dass die Änderungen den Barrierefreiheitsrichtlinien entsprechen.


## Known Issues
_Keine._
